### PR TITLE
Improve Markdown compatibility with Pandoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Diese Version wurde wiederum mehrfach erweitert und um ein Makefile ergänzt.
 
 rechnung.sty ist der Versuch das Erstellen von Bestellungen und Rechnungen mit LaTeX 2e zu erleichtern.
 Dazu verfügt rechnung.sty über folgende Fähigkeiten:
+
 * Automatisches Durchnumerieren der Positionen
 * Automatischer Umbruch langer Artikelbezeichnungen
 * Varianten mit und ohne Artikelnummern
@@ -21,12 +22,16 @@ Dazu verfügt rechnung.sty über folgende Fähigkeiten:
 * horizontale Trennlinien zwischen den einzelnen Artikeln können abgeschaltet werden.
 
 ## Einschränkungen/bekannte Bugs:
+
 * rechnung.sty bricht zwar die Tabelle um, fügt aber nach einem Umbruch keine neue Kopfzeile ein.
 
 ## Installation
+
 Die installation kann entweder durch das Kommando `make install && make install.dvi` automatisiert oder manuell ausgeführt werden:
 
 ### Manuelle installation
+
 * Zuerst rechnung.sty erzeugen: `latex rechnung.ins`
 * Dann die Dokumentation: `latex rechnung.dtx`
-* rechnung.sty muss in den Pfad von LaTeX 2e `.../tex/latex/` ,wobei "..." systemspezifisch ist.
+* rechnung.sty muss in den Pfad von LaTeX 2e `.../tex/latex/`, wobei „`...`“ systemspezifisch ist.
+


### PR DESCRIPTION
`pandoc README.md -o README.pdf` totally clobbers the feature list.
Add newlines to fix.

Also fix one typo and a pair of quotes.