### PR TITLE
Workflow für einige Teile des Makefile erstellt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: rechnung
+on: [push]
+
+jobs:
+  make_all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            make
+  make_example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            make example
+  rechnung_pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: rechnung.sty und rechnung.pdf erstellen
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            latex rechnung.ins
+            pdflatex rechnung.dtx
+      - name: rechnung.pdf speichern
+        uses: actions/upload-artifact@v3
+        with:
+          name: rechnung.pdf
+          path: rechnung.pdf


### PR DESCRIPTION
Damit ein Problem wie #18 nicht mehr auftreten kann, wird ein Workflow erstellt, der bei jeder Code-Änderung prüft, ob der LaTeX-Code ohne Fehler abbricht.

Im ersten Schritt werden einige Teile des _Makefile_ durchlaufen und die _rechnung.pdf_ erstellt. (Leider als ZIP-Datei, so dass man erneut klicken muss.)

Das Ergebnis von dem PR kann man sich [hier](https://github.com/Daniel-at-git/rechnung/actions/runs/3776492665) ansehen.

2000 CI/CD Minuten sind pro Monat kostenlos. Das sollte problemlos reichen ;-)
[https://github.com/pricing](https://github.com/pricing)

### Zukünftige Implementierungen
- Ggf. wird in den weiteren Schritten noch _make rechnung.dvi_ und _make rechnungman.dvi_ geprüft, die sich derzeit beim Ausführen von _makeindex_ mit einem Fehler beenden (aber die Dateien trotzdem generieren).

- Ebenfalls könnte man damit ein _Release_ automatisch generieren und die _rechnung.pdf_ darüber bereitstellen. Im ersten Versuch hat dies jedoch _Tags_ generiert, die das einfache Arbeiten mit _git_ gestört haben (Tag=master und Branch=master).

